### PR TITLE
fix: pin GitHub Actions to commit SHAs (INT-326)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Trunk Check
-        uses: trunk-io/trunk-action@v1
+        uses: trunk-io/trunk-action@75699af9e26881e564e9d832ef7dc3af25ec031b # v1.2.4
       - name: Set up Terraform CLI
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
       - run: terraform fmt -check -recursive

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -6,23 +6,23 @@ cli:
 plugins:
   sources:
     - id: trunk
-      ref: v1.4.2
+      ref: v1.7.6
       uri: https://github.com/trunk-io/plugins
 runtimes:
   enabled:
-    - node@18.12.1
+    - node@22.16.0
     - python@3.10.8
 lint:
   enabled:
-    - actionlint@1.6.9
-    - terrascan@1.18.1
+    - actionlint@1.7.8
+    - terrascan@1.19.1
     - checkov@3.2.513
     - git-diff-check
     - markdownlint@0.48.0
     - prettier@3.8.1
-    - tflint@0.50.3
-    - trivy@0.49.1
-    - trufflehog@3.67.5
+    - tflint@0.59.1
+    - trivy@0.69.2
+    - trufflehog@3.90.13
     - yamllint@1.38.0
 actions:
   enabled:

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,7 +2,7 @@
 # To learn more about the format of this file, see https://docs.trunk.io/reference/trunk-yaml
 version: 0.1
 cli:
-  version: 1.19.0
+  version: 1.25.0
 plugins:
   sources:
     - id: trunk
@@ -14,14 +14,16 @@ runtimes:
     - python@3.10.8
 lint:
   enabled:
-    - checkov@3.2.19
+    - actionlint@1.6.9
+    - terrascan@1.18.1
+    - checkov@3.2.513
     - git-diff-check
-    - markdownlint@0.39.0
-    - prettier@3.2.5
+    - markdownlint@0.48.0
+    - prettier@3.8.1
     - tflint@0.50.3
     - trivy@0.49.1
     - trufflehog@3.67.5
-    - yamllint@1.34.0
+    - yamllint@1.38.0
 actions:
   enabled:
     - trunk-announce


### PR DESCRIPTION
## Info

- Pins all `uses:` references in GitHub Actions workflows to full commit SHAs.

## References

- https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development infrastructure dependencies and pinned GitHub Actions to latest versions
  * Upgraded development tooling, linting utilities, and build environment runtime to newer versions for improved stability and compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->