### PR TITLE
chore: zizmor trunk plugin and reusable workflows (INT-1582)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,20 +2,17 @@ name: Lint
 
 on: pull_request
 
-permissions:
-  actions: read
-  checks: write
-  contents: read
-  pull-requests: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out Git repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Trunk Check
-        uses: trunk-io/trunk-action@75699af9e26881e564e9d832ef7dc3af25ec031b # v1.2.4
-      - name: Set up Terraform CLI
-        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
-      - run: terraform fmt -check -recursive
+    uses: masterpointio/actions/.github/workflows/lint.yaml@7dad35e85d864ca5dda0971dfd3c940cc67ed380 #v0.3.0
+    permissions:
+      actions: read # for trunk-action
+      checks: write # for trunk-action
+      contents: read # for trunk-action + checkout
+      pull-requests: read # for action-semantic-pull-request

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -6,7 +6,7 @@ cli:
 plugins:
   sources:
     - id: trunk
-      ref: v1.7.6
+      ref: v1.10.1
       uri: https://github.com/trunk-io/plugins
 runtimes:
   enabled:
@@ -24,6 +24,19 @@ lint:
     - trivy@0.69.2
     - trufflehog@3.90.13
     - yamllint@1.38.0
+    - zizmor@1.25.2
+  definitions:
+    - name: zizmor
+      environment:
+        # Optional token here so that it's not needed locally, but can be used
+        # when trunk is called from our lint workflow in GHA
+        - name: ZIZMOR_GITHUB_TOKEN
+          value: ${env.GITHUB_TOKEN}
+          optional: true
+      commands:
+        # Set to pedantic so that zizmor will run its stale-action-refs audit rule
+        - name: lint
+          run: zizmor --format=sarif --persona=pedantic ${target}
 actions:
   enabled:
     - trunk-announce


### PR DESCRIPTION
## what

- Refactor workflows to utilize reusable/centralized workflows in our actions repo
- Add the Zizmor plugin to trunk, for static analysis of our Github Actions

## why

- Align this repo with our centralized standard workflows
- Improve our security posture with zizmor and also set an example for clients

## references

- [INT-1582](https://www.notion.so/masterpoint/Roll-out-Zizmor-across-all-Masterpoint-OSS-repos-08a6992b18de4b9581bec3eb579715b1)